### PR TITLE
New Channel Method Function 'SetAppHasStarted'

### DIFF
--- a/android/src/main/java/com/twilio/twilio_voice/AnswerJavaActivity.java
+++ b/android/src/main/java/com/twilio/twilio_voice/AnswerJavaActivity.java
@@ -396,7 +396,7 @@ public class AnswerJavaActivity extends AppCompatActivity {
 
     @Override
     protected void onDestroy() {
-        Log.d(TAG, "AnserJAvaActivity ondestroy");
+        Log.d(TAG, "AnwserJAvaActivity ondestroy");
 //        unregisterReceiver();
         super.onDestroy();
         if (wakeLock != null) {

--- a/android/src/main/java/com/twilio/twilio_voice/IncomingCallNotificationService.java
+++ b/android/src/main/java/com/twilio/twilio_voice/IncomingCallNotificationService.java
@@ -339,7 +339,7 @@ public class IncomingCallNotificationService extends Service {
         pluginIntent.putExtra(Constants.INCOMING_CALL_NOTIFICATION_ID, notificationId);
         pluginIntent.putExtra(Constants.INCOMING_CALL_INVITE, callInvite);
         LocalBroadcastManager.getInstance(this).sendBroadcast(pluginIntent);
-        if (TwilioVoicePlugin.hasStarted || (Build.VERSION.SDK_INT >= 29 && !isAppVisible())) {
+        if ((TwilioVoicePlugin.appHasStarted || Build.VERSION.SDK_INT >= 29 && !isAppVisible())) {
             return;
         }
         startAnswerActivity(callInvite, notificationId);

--- a/android/src/main/java/com/twilio/twilio_voice/IncomingCallNotificationService.java
+++ b/android/src/main/java/com/twilio/twilio_voice/IncomingCallNotificationService.java
@@ -339,7 +339,7 @@ public class IncomingCallNotificationService extends Service {
         pluginIntent.putExtra(Constants.INCOMING_CALL_NOTIFICATION_ID, notificationId);
         pluginIntent.putExtra(Constants.INCOMING_CALL_INVITE, callInvite);
         LocalBroadcastManager.getInstance(this).sendBroadcast(pluginIntent);
-        if ((TwilioVoicePlugin.appHasStarted || Build.VERSION.SDK_INT >= 29 && !isAppVisible())) {
+        if (TwilioVoicePlugin.appHasStarted || (Build.VERSION.SDK_INT >= 29 && !isAppVisible())) {
             return;
         }
         startAnswerActivity(callInvite, notificationId);

--- a/android/src/main/java/com/twilio/twilio_voice/TwilioVoicePlugin.java
+++ b/android/src/main/java/com/twilio/twilio_voice/TwilioVoicePlugin.java
@@ -58,7 +58,7 @@ public class TwilioVoicePlugin implements FlutterPlugin, MethodChannel.MethodCal
     private static final String TAG = "TwilioVoicePlugin";
     public static final String TwilioPreferences = "com.twilio.twilio_voicePreferences";
     private static final int MIC_PERMISSION_REQUEST_CODE = 1;
-    static boolean hasStarted = false;
+    // static boolean hasStarted = false;
     static boolean appHasStarted = false;
 
     private String accessToken;
@@ -92,7 +92,7 @@ public class TwilioVoicePlugin implements FlutterPlugin, MethodChannel.MethodCal
     @Override
     public void onAttachedToEngine(@NonNull FlutterPluginBinding flutterPluginBinding) {
         register(flutterPluginBinding.getBinaryMessenger(), this, flutterPluginBinding.getApplicationContext());
-        hasStarted = true;
+        /*hasStarted = true;*/
     }
 
     private static void register(BinaryMessenger messenger, TwilioVoicePlugin plugin, Context context) {

--- a/android/src/main/java/com/twilio/twilio_voice/TwilioVoicePlugin.java
+++ b/android/src/main/java/com/twilio/twilio_voice/TwilioVoicePlugin.java
@@ -59,6 +59,7 @@ public class TwilioVoicePlugin implements FlutterPlugin, MethodChannel.MethodCal
     public static final String TwilioPreferences = "com.twilio.twilio_voicePreferences";
     private static final int MIC_PERMISSION_REQUEST_CODE = 1;
     static boolean hasStarted = false;
+    static boolean appHasStarted = false;
 
     private String accessToken;
     private AudioManager audioManager;
@@ -359,6 +360,7 @@ public class TwilioVoicePlugin implements FlutterPlugin, MethodChannel.MethodCal
         methodChannel = null;
         eventChannel.setStreamHandler(null);
         eventChannel = null;
+        appHasStarted = false;
     }
 
     @Override
@@ -371,6 +373,10 @@ public class TwilioVoicePlugin implements FlutterPlugin, MethodChannel.MethodCal
     public void onCancel(Object o) {
         Log.i(TAG, "Removing event sink");
         this.eventSink = null;
+    }
+
+    public Boolean isAppStarted() {
+        return this.appHasStarted;
     }
 
     @Override
@@ -519,6 +525,9 @@ public class TwilioVoicePlugin implements FlutterPlugin, MethodChannel.MethodCal
                 localIntent.putExtra("extra_pkgname", activity.getPackageName());
                 activity.startActivity(localIntent);
             }
+            result.success(true);
+        } else if (call.method.equals("setAppHasStarted")) {
+            this.appHasStarted = call.argument("appHasStarted");
             result.success(true);
         } else {
             result.notImplemented();

--- a/lib/twilio_voice.dart
+++ b/lib/twilio_voice.dart
@@ -2,6 +2,7 @@ library twilio_voice;
 
 import 'dart:async';
 import 'dart:convert';
+import 'dart:io';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/services.dart';
 
@@ -45,8 +46,11 @@ class TwilioVoice {
     return _channel.invokeMethod('loadDeviceToken', <String, dynamic>{});
   }
 
+  // Android only for TwilioVoicePlugin.java
   Future<void> setAppHasStarted({required bool appHasStarted}) async {
-    await _channel.invokeMethod('setAppHasStarted', <String, dynamic>{"appHasStarted": appHasStarted});
+    if (Platform.isAndroid) {
+      await _channel.invokeMethod('setAppHasStarted', <String, dynamic>{"appHasStarted": appHasStarted});
+    }
   }
 
   /// register fcm token, and device token for android

--- a/lib/twilio_voice.dart
+++ b/lib/twilio_voice.dart
@@ -45,6 +45,10 @@ class TwilioVoice {
     return _channel.invokeMethod('loadDeviceToken', <String, dynamic>{});
   }
 
+  Future<void> setAppHasStarted({required bool appHasStarted}) async {
+    await _channel.invokeMethod('setAppHasStarted', <String, dynamic>{"appHasStarted": appHasStarted});
+  }
+
   /// register fcm token, and device token for android
   ///
   /// ios device token is obtained internally
@@ -138,12 +142,12 @@ class TwilioVoice {
 
       // source: https://www.twilio.com/docs/api/errors/31603
       // The callee does not wish to participate in the call.
-      if(tokens[1].contains("31603")) {
+      if (tokens[1].contains("31603")) {
         return CallEvent.declined;
-      } else if(tokens.toString().toLowerCase().contains("call rejected")) {
+      } else if (tokens.toString().toLowerCase().contains("call rejected")) {
         // Android call reject from string: "LOG|Call Rejected"
         return CallEvent.declined;
-      } else if(tokens.toString().toLowerCase().contains("rejecting call")) {
+      } else if (tokens.toString().toLowerCase().contains("rejecting call")) {
         // iOS call reject froms tring: "LOG|provider:performEndCallAction: rejecting call"
         return CallEvent.declined;
       }
@@ -266,7 +270,8 @@ class Call {
 
   /// Gets the active call's SID. This will be null until the first Ringing event occurs
   Future<String?> getSid() {
-    return _channel.invokeMethod<String?>('call-sid', <String, dynamic>{}).then<String?>((String? value) => value);
+    return _channel.invokeMethod<String?>('call-sid',
+        <String, dynamic>{}).then<String?>((String? value) => value);
   }
 
   /// Answers incoming call


### PR DESCRIPTION
Created a new Channel Method Function called 'SetAppHasStarted' that is to replace the TwilioVoicePlugin.hasStarted flag.

Instead of the flag being created on 'onAttachedToEngine' in TwilioVoicePlugin.java, we are setting this new flag through main.dart. This tells Plugin that the app is running whether that be in the foreground or background and to handle incoming calls as such.