### PR TITLE
Bugfixes/cc/phase3 Android calling with device pin fix

### DIFF
--- a/android/src/main/java/com/twilio/twilio_voice/AnswerJavaActivity.java
+++ b/android/src/main/java/com/twilio/twilio_voice/AnswerJavaActivity.java
@@ -144,6 +144,13 @@ public class AnswerJavaActivity extends AppCompatActivity {
                 case Constants.ACTION_CANCEL_CALL:
                     newCancelCallClickListener();
                     break;
+                case Constants.ACTION_ACCEPT:
+                    Intent backgroundCallIntent = new Intent(this, BackgroundCallJavaActivity.class);
+                    backgroundCallIntent.addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP);
+                    backgroundCallIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+                    backgroundCallIntent.putExtra(Constants.CALL_FROM, "SchoolStatus");
+                    startActivity(backgroundCallIntent);
+                    Log.d(TAG, "Connected");
                 default: {
                 }
             }
@@ -198,6 +205,7 @@ public class AnswerJavaActivity extends AppCompatActivity {
         acceptIntent.putExtra(Constants.INCOMING_CALL_NOTIFICATION_ID, activeCallNotificationId);
         Log.d(TAG, "Clicked accept startService");
         startService(acceptIntent);
+        Log.d(TAG, "!isLocked(): " + !isLocked() + " appHasStarted: " + TwilioVoicePlugin.appHasStarted);
         if (!isLocked() && TwilioVoicePlugin.appHasStarted) {
             finish();
         } else {

--- a/android/src/main/java/com/twilio/twilio_voice/AnswerJavaActivity.java
+++ b/android/src/main/java/com/twilio/twilio_voice/AnswerJavaActivity.java
@@ -206,9 +206,11 @@ public class AnswerJavaActivity extends AppCompatActivity {
         Log.d(TAG, "Clicked accept startService");
         startService(acceptIntent);
         Log.d(TAG, "!isLocked(): " + !isLocked() + " appHasStarted: " + TwilioVoicePlugin.appHasStarted);
-        if (!isLocked() && TwilioVoicePlugin.appHasStarted) {
+        if (TwilioVoicePlugin.appHasStarted) {
+            Log.d(TAG, "AnswerJavaActivity Finish");
             finish();
-        } else {
+        }
+        else {
             Log.d(TAG, "Answering call");
             activeCallInvite.accept(this, callListener);
             notificationManager.cancel(activeCallNotificationId);

--- a/android/src/main/java/com/twilio/twilio_voice/AnswerJavaActivity.java
+++ b/android/src/main/java/com/twilio/twilio_voice/AnswerJavaActivity.java
@@ -144,13 +144,6 @@ public class AnswerJavaActivity extends AppCompatActivity {
                 case Constants.ACTION_CANCEL_CALL:
                     newCancelCallClickListener();
                     break;
-                case Constants.ACTION_ACCEPT:
-                    Intent backgroundCallIntent = new Intent(this, BackgroundCallJavaActivity.class);
-                    backgroundCallIntent.addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP);
-                    backgroundCallIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
-                    backgroundCallIntent.putExtra(Constants.CALL_FROM, "SchoolStatus");
-                    startActivity(backgroundCallIntent);
-                    Log.d(TAG, "Connected");
                 default: {
                 }
             }
@@ -205,7 +198,7 @@ public class AnswerJavaActivity extends AppCompatActivity {
         acceptIntent.putExtra(Constants.INCOMING_CALL_NOTIFICATION_ID, activeCallNotificationId);
         Log.d(TAG, "Clicked accept startService");
         startService(acceptIntent);
-        Log.d(TAG, "!isLocked(): " + !isLocked() + " appHasStarted: " + TwilioVoicePlugin.appHasStarted);
+        Log.d(TAG, "isLocked: " + isLocked() + " appHasStarted: " + TwilioVoicePlugin.appHasStarted);
         if (TwilioVoicePlugin.appHasStarted) {
             Log.d(TAG, "AnswerJavaActivity Finish");
             finish();

--- a/android/src/main/java/com/twilio/twilio_voice/AnswerJavaActivity.java
+++ b/android/src/main/java/com/twilio/twilio_voice/AnswerJavaActivity.java
@@ -239,7 +239,7 @@ public class AnswerJavaActivity extends AppCompatActivity {
             intent.setAction(Constants.ACTION_CANCEL_CALL);
 
             this.startActivity(intent);
-            finish();
+            finishAndRemoveTask();
         }
 
     }

--- a/android/src/main/java/com/twilio/twilio_voice/BackgroundCallJavaActivity.java
+++ b/android/src/main/java/com/twilio/twilio_voice/BackgroundCallJavaActivity.java
@@ -167,7 +167,7 @@ public class BackgroundCallJavaActivity extends AppCompatActivity {
             @Override
             public void onClick(View v) {
                 sendIntent(Constants.ACTION_END_CALL);
-                finish();
+                finishAndRemoveTask();
 
             }
         });
@@ -210,6 +210,7 @@ public class BackgroundCallJavaActivity extends AppCompatActivity {
 
 
     private void callCanceled() {
+        Log.d(TAG, "Call is cancelled");
         finish();
     }
 

--- a/android/src/main/java/com/twilio/twilio_voice/BackgroundCallJavaActivity.java
+++ b/android/src/main/java/com/twilio/twilio_voice/BackgroundCallJavaActivity.java
@@ -167,7 +167,7 @@ public class BackgroundCallJavaActivity extends AppCompatActivity {
             @Override
             public void onClick(View v) {
                 sendIntent(Constants.ACTION_END_CALL);
-                finishAndRemoveTask();
+                finish();
 
             }
         });

--- a/android/src/main/java/com/twilio/twilio_voice/IncomingCallNotificationService.java
+++ b/android/src/main/java/com/twilio/twilio_voice/IncomingCallNotificationService.java
@@ -213,7 +213,7 @@ public class IncomingCallNotificationService extends Service {
         SoundPoolManager.getInstance(this).stopRinging();
         Log.i(TAG, "IsAppVisible: " + isAppVisible() + " Origin: " + origin);
         Intent activeCallIntent;
-        if (origin == 0 && !isAppVisible() || isLocked()) {
+        if (origin == 0 && !isAppVisible()) {
             Log.i(TAG, "Creating answerJavaActivity intent");
             activeCallIntent = new Intent(this, AnswerJavaActivity.class);
         } else {
@@ -227,8 +227,8 @@ public class IncomingCallNotificationService extends Service {
         activeCallIntent.putExtra(Constants.INCOMING_CALL_NOTIFICATION_ID, notificationId);
         activeCallIntent.putExtra(Constants.ACCEPT_CALL_ORIGIN, origin);
         activeCallIntent.setAction(Constants.ACTION_ACCEPT);
-        Log.i(TAG, "Launch IsAppVisible && !isAppVisible: " + (origin == 0 && !isAppVisible()) + " isLocked: " + isLocked());
-        if (origin == 0 && !isAppVisible() || isLocked()) {
+        Log.i(TAG, "Launch IsAppVisible && !isAppVisible: " + (origin == 0 && !isAppVisible()));
+        if (origin == 0 && !isAppVisible()) {
             startActivity(activeCallIntent);
             Log.i(TAG, "starting activity");
         } else {

--- a/android/src/main/java/com/twilio/twilio_voice/IncomingCallNotificationService.java
+++ b/android/src/main/java/com/twilio/twilio_voice/IncomingCallNotificationService.java
@@ -344,11 +344,6 @@ public class IncomingCallNotificationService extends Service {
         }
     }
 
-    private boolean isLocked() {
-        KeyguardManager myKM = (KeyguardManager) getSystemService(Context.KEYGUARD_SERVICE);
-        return myKM.inKeyguardRestrictedInputMode();
-    }
-
     /*
      * Send the CallInvite to the VoiceActivity. Start the activity if it is not running already.
      */
@@ -362,9 +357,10 @@ public class IncomingCallNotificationService extends Service {
         pluginIntent.putExtra(Constants.INCOMING_CALL_NOTIFICATION_ID, notificationId);
         pluginIntent.putExtra(Constants.INCOMING_CALL_INVITE, callInvite);
         LocalBroadcastManager.getInstance(this).sendBroadcast(pluginIntent);
-        Log.i(TAG, "AppHasStarted && !isLocked(): " + (TwilioVoicePlugin.appHasStarted && !isLocked()) + " sdk>=29 and !isAppVisible() " + (Build.VERSION.SDK_INT >= 29 && !isAppVisible()));
-        if ((TwilioVoicePlugin.appHasStarted && !isLocked()) || (Build.VERSION.SDK_INT >= 29 && !isAppVisible())) {
+        Log.i(TAG, "AppHasStarted " + TwilioVoicePlugin.appHasStarted + " sdk>=29 and !isAppVisible() " + (Build.VERSION.SDK_INT >= 29 && !isAppVisible()));
+        if (TwilioVoicePlugin.appHasStarted || (Build.VERSION.SDK_INT >= 29 && !isAppVisible())) {            
             return;
+            
         }
         Log.i(TAG, "Starting AnswerActivity from IncomingCallNotificationService");
         startAnswerActivity(callInvite, notificationId);

--- a/android/src/main/java/com/twilio/twilio_voice/TwilioVoicePlugin.java
+++ b/android/src/main/java/com/twilio/twilio_voice/TwilioVoicePlugin.java
@@ -148,8 +148,8 @@ public class TwilioVoicePlugin implements FlutterPlugin, MethodChannel.MethodCal
                     break;
                 case Constants.ACTION_ACCEPT:
                         int acceptOrigin = intent.getIntExtra(Constants.ACCEPT_CALL_ORIGIN,0);
-                        if(acceptOrigin == 0 || isLocked()){
-                            Log.d(TAG, "Origin 0 or Device is locked. Sending to AnswerJavaActivity");
+                        if(acceptOrigin == 0){
+                            Log.d(TAG, "Origin is 0 sending to AnswerJavaActivity");
                             Intent answerIntent = new Intent(activity, AnswerJavaActivity.class);
                             answerIntent.setAction(Constants.ACTION_ACCEPT);
                             answerIntent.putExtra(Constants.INCOMING_CALL_NOTIFICATION_ID, activeCallNotificationId);
@@ -546,12 +546,6 @@ public class TwilioVoicePlugin implements FlutterPlugin, MethodChannel.MethodCal
         sendPhoneCallEvents("Answer|" + activeCallInvite.getFrom() + "|" + activeCallInvite.getTo() + formatCustomParams(activeCallInvite.getCustomParameters()));
         notificationManager.cancel(activeCallNotificationId);
     }
-
-    private boolean isLocked() {
-        KeyguardManager myKM = (KeyguardManager) activity.getSystemService(Context.KEYGUARD_SERVICE);
-        return myKM.inKeyguardRestrictedInputMode();
-    }
-
 
     private void sendPhoneCallEvents(String description) {
         if (eventSink == null) {

--- a/android/src/main/java/com/twilio/twilio_voice/TwilioVoicePlugin.java
+++ b/android/src/main/java/com/twilio/twilio_voice/TwilioVoicePlugin.java
@@ -17,7 +17,6 @@ import java.util.Map;
 
 import android.Manifest;
 import android.app.Activity;
-import android.app.KeyguardManager;
 import android.app.NotificationManager;
 import android.content.BroadcastReceiver;
 import android.content.Context;


### PR DESCRIPTION
The fix was simpler than I thought
* Remove check for isLocked when accepting call - was sending us down wrong code paths. Once I noticed that and removed it the calling starting behaving properly and catching call events.
* Added additional finishAndRemove() during call_canceled event - this is when an incoming call is hung up from the caller (not you). I noticed it wouldn't close the blue screen previously. 

The rest of the changes are extra log statements