### PR TITLE
comm-940: background color was reverting to previous color, update both as fix

### DIFF
--- a/android/src/main/res/layout/activity_answer.xml
+++ b/android/src/main/res/layout/activity_answer.xml
@@ -5,7 +5,7 @@
         android:id="@+id/coordinator_layout"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:background="@color/background"
+        android:background="@color/primary"
         android:fitsSystemWindows="true">
 
     <LinearLayout

--- a/android/src/main/res/layout/activity_background_call.xml
+++ b/android/src/main/res/layout/activity_background_call.xml
@@ -5,7 +5,7 @@
     android:id="@+id/coordinator_layout"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:background="@color/background"
+    android:background="@color/primary"
     android:fitsSystemWindows="true">
 
     <LinearLayout

--- a/android/src/main/res/values/colors.xml
+++ b/android/src/main/res/values/colors.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <color name="primary">#279DE1</color>
+    <color name="primary">#1E2425</color>
     <color name="background">#1E2425</color>
     <color name="accent">#1b6e9e</color>
 


### PR DESCRIPTION
[COMM-940](https://ss-group.atlassian.net/browse/COMM-940)
Hopeful fix for color issue, currently reverting to old color for incoming calls in local testing. New icon is correctly rendering. 

[COMM-940]: https://ss-group.atlassian.net/browse/COMM-940?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ