### PR TITLE
feat: iOS 26 VoIP support with AppDelegate PKPushRegistry

### DIFF
--- a/ios/Classes/SwiftTwilioVoicePlugin.swift
+++ b/ios/Classes/SwiftTwilioVoicePlugin.swift
@@ -6,35 +6,39 @@ import TwilioVoice
 import CallKit
 import UserNotifications
 
-public class SwiftTwilioVoicePlugin: NSObject, FlutterPlugin,  FlutterStreamHandler, PKPushRegistryDelegate, NotificationDelegate, CallDelegate, AVAudioPlayerDelegate, CXProviderDelegate {
+public class SwiftTwilioVoicePlugin: NSObject, FlutterPlugin, FlutterStreamHandler, PKPushRegistryDelegate, NotificationDelegate, CallDelegate, AVAudioPlayerDelegate, CXProviderDelegate {
     
-
+    // MARK: - Singleton
+    private static var sharedInstance: SwiftTwilioVoicePlugin?
+    
+    // MARK: - Properties
     var _result: FlutterResult?
     private var eventSink: FlutterEventSink?
     
     let kRegistrationTTLInDays = 365
-    
     let kCachedDeviceToken = "CachedDeviceToken"
     let kCachedBindingDate = "CachedBindingDate"
     let kClientList = "TwilioContactList"
     private var clients: [String:String]!
     
-    var accessToken:String?
+    var accessToken: String?
     var identity = "alice"
     var callTo: String = "error"
     var defaultCaller = "Unknown Caller"
     var deviceToken: Data? {
-        get{UserDefaults.standard.data(forKey: kCachedDeviceToken)}
-        set{UserDefaults.standard.setValue(newValue, forKey: kCachedDeviceToken)}
+        get { UserDefaults.standard.data(forKey: kCachedDeviceToken) }
+        set { UserDefaults.standard.setValue(newValue, forKey: kCachedDeviceToken) }
     }
     var callArgs: Dictionary<String, AnyObject> = [String: AnyObject]()
     
-    var voipRegistry: PKPushRegistry
-    var incomingPushCompletionCallback: (()->Swift.Void?)? = nil
+    // Push completion callback - CRITICAL for iOS 26 compliance
+    // Must be called AFTER reportNewIncomingCall, not before
+    var pendingPushCompletion: (() -> Void)?
+    var pushCompletionTimer: DispatchWorkItem?
     
-    var callInvite:CallInvite?
-    var call:Call?
-    var callKitCompletionCallback: ((Bool)->Swift.Void?)? = nil
+    var callInvite: CallInvite?
+    var call: Call?
+    var callKitCompletionCallback: ((Bool) -> Swift.Void?)?
     var audioDevice: DefaultAudioDevice = DefaultAudioDevice()
     
     var callKitProvider: CXProvider
@@ -48,10 +52,8 @@ public class SwiftTwilioVoicePlugin: NSObject, FlutterPlugin,  FlutterStreamHand
         }
     }
     
+    // MARK: - Initialization
     public override init() {
-        
-        //isSpinning = false
-        voipRegistry = PKPushRegistry.init(queue: DispatchQueue.main)
         let configuration = CXProviderConfiguration(localizedName: SwiftTwilioVoicePlugin.appName)
         configuration.maximumCallGroups = 1
         configuration.maximumCallsPerCallGroup = 1
@@ -59,60 +61,170 @@ public class SwiftTwilioVoicePlugin: NSObject, FlutterPlugin,  FlutterStreamHand
             configuration.iconTemplateImageData = callKitIcon.pngData()
         }
         
-        clients = UserDefaults.standard.object(forKey: kClientList)  as? [String:String] ?? [:]
+        clients = UserDefaults.standard.object(forKey: kClientList) as? [String:String] ?? [:]
         callKitProvider = CXProvider(configuration: configuration)
         callKitCallController = CXCallController()
         
-        //super.init(coder: aDecoder)
         super.init()
+        
+        NSLog("[TwilioVoice] Plugin init()")
         
         callKitProvider.setDelegate(self, queue: nil)
         
-        voipRegistry.delegate = self
-        voipRegistry.desiredPushTypes = Set([PKPushType.voIP])
-
-        // UIScene-compatible way to get FlutterViewController
-        // Try UIScene first, then fall back to AppDelegate for backward compatibility
-        var controller: FlutterViewController?
+        // Set up NotificationCenter observers for AppDelegate VoIP events
+        // On iOS 26+, PKPushRegistry MUST be initialized in AppDelegate before Flutter
+        setupAppDelegateObservers()
         
-        if #available(iOS 13.0, *) {
-            // For UIScene-based apps (Flutter 3.41+)
-            if let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
-               let window = windowScene.windows.first,
-               let rootVC = window.rootViewController as? FlutterViewController {
-                controller = rootVC
-            }
-        }
-        
-        // Fallback for older apps without UIScene
-        if controller == nil {
-            if let appDelegate = UIApplication.shared.delegate,
-               let window = appDelegate.window,
-               let rootVC = window?.rootViewController as? FlutterViewController {
-                controller = rootVC
-            }
-        }
-        
-        // Event channel setup will happen in register(with:) if controller not available yet
-        if let flutterController = controller {
-            let registrar = flutterController.registrar(forPlugin: "twilio_voice")
-            if let unwrappedRegistrar = registrar {
-                let eventChannel = FlutterEventChannel(name: "twilio_voice/events", binaryMessenger: unwrappedRegistrar.messenger())
-                eventChannel.setStreamHandler(self)
-            }
-        }
+        // Check if AppDelegate already has a VoIP token
+        checkForExistingVoIPToken()
     }
     
-    
     deinit {
-        // CallKit has an odd API contract where the developer must call invalidate or the CXProvider is leaked.
+        NotificationCenter.default.removeObserver(self)
         callKitProvider.invalidate()
     }
     
+    // MARK: - AppDelegate Communication
+    
+    private func setupAppDelegateObservers() {
+        NSLog("[TwilioVoice] Setting up AppDelegate observers")
+        
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(handleAppDelegateVoIPToken(_:)),
+            name: NSNotification.Name("AppDelegateVoIPTokenUpdated"),
+            object: nil
+        )
+        
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(handleAppDelegateVoIPPush(_:)),
+            name: NSNotification.Name("AppDelegateVoIPPushReceived"),
+            object: nil
+        )
+        
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(handleAppDelegateVoIPTokenInvalidated(_:)),
+            name: NSNotification.Name("AppDelegateVoIPTokenInvalidated"),
+            object: nil
+        )
+    }
+    
+    private func checkForExistingVoIPToken() {
+        if let appDelegate = UIApplication.shared.delegate,
+           appDelegate.responds(to: Selector(("getVoIPToken"))),
+           let token = appDelegate.perform(Selector(("getVoIPToken")))?.takeUnretainedValue() as? Data {
+            let hex = token.map { String(format: "%02x", $0) }.joined()
+            NSLog("[TwilioVoice] Found existing VoIP token: \(hex)")
+            handleVoIPTokenUpdate(token: token)
+        }
+    }
+    
+    @objc private func handleAppDelegateVoIPToken(_ notification: Notification) {
+        guard let userInfo = notification.userInfo,
+              let token = userInfo["token"] as? Data else {
+            NSLog("[TwilioVoice] ERROR: Invalid token notification")
+            return
+        }
+        
+        let hex = token.map { String(format: "%02x", $0) }.joined()
+        NSLog("[TwilioVoice] VoIP token from AppDelegate: \(hex)")
+        handleVoIPTokenUpdate(token: token)
+    }
+    
+    @objc private func handleAppDelegateVoIPPush(_ notification: Notification) {
+        NSLog("[TwilioVoice] *** VoIP PUSH RECEIVED ***")
+        self.sendPhoneCallEvents(description: "LOG|*** VoIP PUSH RECEIVED ***", isError: false)
+        
+        guard let userInfo = notification.userInfo,
+              let payload = userInfo["payload"] as? [AnyHashable: Any] else {
+            NSLog("[TwilioVoice] ERROR: Invalid push payload")
+            return
+        }
+        
+        let mustReport = userInfo["mustReport"] as? Bool ?? true
+        let completion = userInfo["completion"] as? (() -> Void)
+        
+        NSLog("[TwilioVoice] Push mustReport=\(mustReport), payload keys: \(payload.keys)")
+        self.sendPhoneCallEvents(description: "LOG|Push mustReport=\(mustReport)", isError: false)
+        
+        // Store completion - will be called AFTER reportNewIncomingCall (F1 fix)
+        self.pendingPushCompletion = completion
+        
+        // Safety timeout: complete after 5s if Twilio SDK doesn't callback
+        pushCompletionTimer?.cancel()
+        let timer = DispatchWorkItem { [weak self] in
+            NSLog("[TwilioVoice] Push completion timeout - forcing completion")
+            self?.completePendingPush()
+        }
+        pushCompletionTimer = timer
+        DispatchQueue.main.asyncAfter(deadline: .now() + 5, execute: timer)
+        
+        // Handle with Twilio SDK
+        TwilioVoiceSDK.handleNotification(payload, delegate: self, delegateQueue: nil)
+    }
+    
+    @objc private func handleAppDelegateVoIPTokenInvalidated(_ notification: Notification) {
+        NSLog("[TwilioVoice] VoIP token invalidated")
+        self.sendPhoneCallEvents(description: "LOG|VoIP token invalidated", isError: false)
+        self.unregister()
+    }
+    
+    private func handleVoIPTokenUpdate(token: Data) {
+        self.sendPhoneCallEvents(description: "LOG|VoIP token received", isError: false)
+        
+        let regRequired = registrationRequired()
+        let tokenChanged = deviceToken != token
+        
+        guard regRequired || tokenChanged else {
+            self.sendPhoneCallEvents(description: "LOG|Registration not required", isError: false)
+            return
+        }
+        
+        if let accessToken = self.accessToken {
+            self.sendPhoneCallEvents(description: "LOG|Registering with Twilio", isError: false)
+            TwilioVoiceSDK.register(accessToken: accessToken, deviceToken: token) { error in
+                if let error = error {
+                    self.sendPhoneCallEvents(description: "LOG|Registration error: \(error.localizedDescription)", isError: false)
+                } else {
+                    self.sendPhoneCallEvents(description: "LOG|Successfully registered for VoIP push", isError: false)
+                }
+            }
+        } else {
+            self.sendPhoneCallEvents(description: "LOG|No accessToken yet, caching token", isError: false)
+        }
+        
+        self.deviceToken = token
+        UserDefaults.standard.set(Date(), forKey: kCachedBindingDate)
+    }
+    
+    private func completePendingPush() {
+        pushCompletionTimer?.cancel()
+        pushCompletionTimer = nil
+        
+        if let completion = pendingPushCompletion {
+            NSLog("[TwilioVoice] Completing push")
+            pendingPushCompletion = nil
+            completion()
+        }
+    }
+    
+    // MARK: - Plugin Registration
     
     public static func register(with registrar: FlutterPluginRegistrar) {
+        NSLog("[TwilioVoice] register(with:) called")
         
-        let instance = SwiftTwilioVoicePlugin()
+        let instance: SwiftTwilioVoicePlugin
+        if let existing = sharedInstance {
+            instance = existing
+            NSLog("[TwilioVoice] Reusing existing instance")
+        } else {
+            instance = SwiftTwilioVoicePlugin()
+            sharedInstance = instance
+            NSLog("[TwilioVoice] Created new instance")
+        }
+        
         let methodChannel = FlutterMethodChannel(name: "twilio_voice/messages", binaryMessenger: registrar.messenger())
         let eventChannel = FlutterEventChannel(name: "twilio_voice/events", binaryMessenger: registrar.messenger())
         eventChannel.setStreamHandler(instance)
@@ -120,10 +232,12 @@ public class SwiftTwilioVoicePlugin: NSObject, FlutterPlugin,  FlutterStreamHand
         registrar.addApplicationDelegate(instance)
     }
     
+    // MARK: - Flutter Method Channel Handler
+    
     public func handle(_ flutterCall: FlutterMethodCall, result: @escaping FlutterResult) {
         _result = result
         
-        let arguments:Dictionary<String, AnyObject> = flutterCall.arguments as! Dictionary<String, AnyObject>;
+        let arguments: Dictionary<String, AnyObject> = flutterCall.arguments as? Dictionary<String, AnyObject> ?? [:]
         
         if flutterCall.method == "loadDeviceToken" {
             if let deviceToken = deviceToken {
@@ -131,201 +245,228 @@ public class SwiftTwilioVoicePlugin: NSObject, FlutterPlugin,  FlutterStreamHand
                 result(true)
                 return
             }
+            result(false)
+            return
         }
+        
         if flutterCall.method == "tokens" {
-            guard let token = arguments["accessToken"] as? String else {return}
+            guard let token = arguments["accessToken"] as? String else {
+                result(false)
+                return
+            }
             self.accessToken = token
-            if let deviceToken = deviceToken, let token = accessToken {
-                self.sendPhoneCallEvents(description: "LOG|pushRegistry:attempting to register with twilio", isError: false)
-                TwilioVoiceSDK.register(accessToken: token, deviceToken: deviceToken) { (error) in
+            
+            if let deviceToken = deviceToken {
+                self.sendPhoneCallEvents(description: "LOG|Registering with Twilio", isError: false)
+                TwilioVoiceSDK.register(accessToken: token, deviceToken: deviceToken) { error in
                     if let error = error {
-                        self.sendPhoneCallEvents(description: "LOG|An error occurred while registering: \(error.localizedDescription)", isError: false)
-                    }
-                    else {
-                        self.sendPhoneCallEvents(description: "LOG|Successfully registered for VoIP push notifications.", isError: false)
+                        self.sendPhoneCallEvents(description: "LOG|Registration error: \(error.localizedDescription)", isError: false)
+                    } else {
+                        self.sendPhoneCallEvents(description: "LOG|Successfully registered for VoIP push", isError: false)
                     }
                 }
+            } else {
+                self.sendPhoneCallEvents(description: "LOG|No deviceToken yet", isError: false)
             }
-        } else if flutterCall.method == "makeCall" {
-            guard let callTo = arguments["To"] as? String else {return}
-            guard let callFrom = arguments["From"] as? String else {return}
+            result(true)
+            return
+        }
+        
+        if flutterCall.method == "makeCall" {
+            guard let callTo = arguments["To"] as? String else { result(false); return }
+            guard let callFrom = arguments["From"] as? String else { result(false); return }
             self.callArgs = arguments
             self.callOutgoing = true
-            if let accessToken = arguments["accessToken"] as? String{
+            if let accessToken = arguments["accessToken"] as? String {
                 self.accessToken = accessToken
             }
             self.callTo = callTo
             self.identity = callFrom
             makeCall(to: callTo)
+            result(true)
+            return
         }
-        else if flutterCall.method == "toggleMute"
-        {
-            guard let muted = arguments["muted"] as? Bool else {return}
-            if (self.call != nil) {
-
-                self.call!.isMuted = muted
-                guard let eventSink = eventSink else {
-                    return
-                }
-                eventSink(muted ? "Mute" : "Unmute")
+        
+        if flutterCall.method == "toggleMute" {
+            guard let muted = arguments["muted"] as? Bool else { result(false); return }
+            if let call = self.call {
+                call.isMuted = muted
+                eventSink?(muted ? "Mute" : "Unmute")
+                result(true)
             } else {
-                let ferror: FlutterError = FlutterError(code: "MUTE_ERROR", message: "No call to be muted", details: nil)
-                _result!(ferror)
+                result(FlutterError(code: "MUTE_ERROR", message: "No call to be muted", details: nil))
             }
+            return
         }
-        else if flutterCall.method == "toggleSpeaker"
-        {
-            guard let speakerIsOn = arguments["speakerIsOn"] as? Bool else {return}
+        
+        if flutterCall.method == "toggleSpeaker" {
+            guard let speakerIsOn = arguments["speakerIsOn"] as? Bool else { result(false); return }
             toggleAudioRoute(toSpeaker: speakerIsOn)
-            guard let eventSink = eventSink else {
-                return
+            eventSink?(speakerIsOn ? "Speaker On" : "Speaker Off")
+            result(true)
+            return
+        }
+        
+        if flutterCall.method == "call-sid" {
+            result(self.call?.sid)
+            return
+        }
+        
+        if flutterCall.method == "isOnCall" {
+            result(self.call != nil)
+            return
+        }
+        
+        if flutterCall.method == "sendDigits" {
+            guard let digits = arguments["digits"] as? String else { result(false); return }
+            self.call?.sendDigits(digits)
+            result(true)
+            return
+        }
+        
+        if flutterCall.method == "holdCall" {
+            if let call = self.call {
+                let hold = call.isOnHold
+                call.isOnHold = !hold
+                eventSink?(!hold ? "Hold" : "Unhold")
             }
-            eventSink(speakerIsOn ? "Speaker On" : "Speaker Off")
+            result(true)
+            return
         }
-        else if flutterCall.method == "call-sid"
-        {
-            result(self.call == nil ? nil : self.call!.sid);
-            return;
+        
+        if flutterCall.method == "answer" {
+            result(true)
+            return
         }
-        else if flutterCall.method == "isOnCall"
-        {
-            result(self.call != nil);
-            return;
-        }
-        else if flutterCall.method == "sendDigits"
-        {
-            guard let digits = arguments["digits"] as? String else {return}
-            if (self.call != nil) {
-                self.call!.sendDigits(digits);
-            }
-        }
-        /* else if flutterCall.method == "receiveCalls"
-         {
-         guard let clientIdentity = arguments["clientIdentifier"] as? String else {return}
-         self.identity = clientIdentity;
-         } */
-        else if flutterCall.method == "holdCall" {
-            if (self.call != nil) {
-                
-                let hold = self.call!.isOnHold
-                self.call!.isOnHold = !hold
-                guard let eventSink = eventSink else {
-                    return
-                }
-                eventSink(!hold ? "Hold" : "Unhold")
-            }
-        }
-        else if flutterCall.method == "answer" {
-            // nuthin
-        }
-        else if flutterCall.method == "unregister" {
+        
+        if flutterCall.method == "unregister" {
             guard let deviceToken = deviceToken else {
+                result(false)
                 return
             }
-            if let token = arguments["accessToken"] as? String{
+            if let token = arguments["accessToken"] as? String {
                 self.unregisterTokens(token: token, deviceToken: deviceToken)
-            }else if let token = accessToken{
+            } else if let token = accessToken {
                 self.unregisterTokens(token: token, deviceToken: deviceToken)
             }
-            
-        }else if flutterCall.method == "hangUp"{
-            if (self.call != nil && self.call?.state == .connected) {
-                self.sendPhoneCallEvents(description: "LOG|hangUp method invoked", isError: false)
+            result(true)
+            return
+        }
+        
+        if flutterCall.method == "hangUp" {
+            if let call = self.call, call.state == .connected {
+                self.sendPhoneCallEvents(description: "LOG|hangUp invoked", isError: false)
                 self.userInitiatedDisconnect = true
-                performEndCallAction(uuid: self.call!.uuid!)
-                //self.toggleUIState(isEnabled: false, showCallControl: false)
+                performEndCallAction(uuid: call.uuid!)
             }
-        }else if flutterCall.method == "registerClient"{
-            guard let clientId = arguments["id"] as? String, let clientName =  arguments["name"] as? String else {return}
-            if clients[clientId] == nil || clients[clientId] != clientName{
+            result(true)
+            return
+        }
+        
+        if flutterCall.method == "registerClient" {
+            guard let clientId = arguments["id"] as? String,
+                  let clientName = arguments["name"] as? String else { result(false); return }
+            if clients[clientId] == nil || clients[clientId] != clientName {
                 clients[clientId] = clientName
                 UserDefaults.standard.set(clients, forKey: kClientList)
             }
-            
-        }else if flutterCall.method == "unregisterClient"{
-            guard let clientId = arguments["id"] as? String else {return}
+            result(true)
+            return
+        }
+        
+        if flutterCall.method == "unregisterClient" {
+            guard let clientId = arguments["id"] as? String else { result(false); return }
             clients.removeValue(forKey: clientId)
             UserDefaults.standard.set(clients, forKey: kClientList)
-            
-        }else if flutterCall.method == "defaultCaller"{
-            guard let caller = arguments["defaultCaller"] as? String else {return}
+            result(true)
+            return
+        }
+        
+        if flutterCall.method == "defaultCaller" {
+            guard let caller = arguments["defaultCaller"] as? String else { result(false); return }
             defaultCaller = caller
-            if(clients["defaultCaller"] == nil || clients["defaultCaller"] != defaultCaller){
+            if clients["defaultCaller"] == nil || clients["defaultCaller"] != defaultCaller {
                 clients["defaultCaller"] = defaultCaller
                 UserDefaults.standard.set(clients, forKey: kClientList)
             }
-        }else if flutterCall.method == "hasMicPermission" {
+            result(true)
+            return
+        }
+        
+        if flutterCall.method == "hasMicPermission" {
             let permission = AVAudioSession.sharedInstance().recordPermission
             result(permission == .granted)
             return
-        }else if flutterCall.method == "requestMicPermission"{
-            switch(AVAudioSession.sharedInstance().recordPermission){
+        }
+        
+        if flutterCall.method == "requestMicPermission" {
+            switch AVAudioSession.sharedInstance().recordPermission {
             case .granted:
                 result(true)
             case .denied:
                 result(false)
             case .undetermined:
-                AVAudioSession.sharedInstance().requestRecordPermission({ (granted) in
+                AVAudioSession.sharedInstance().requestRecordPermission { granted in
                     result(granted)
-                })
+                }
             @unknown default:
                 result(false)
             }
             return
-        } else if flutterCall.method == "show-notifications" {
-            guard let show = arguments["show"] as? Bool else{return}
+        }
+        
+        if flutterCall.method == "show-notifications" {
+            guard let show = arguments["show"] as? Bool else { result(false); return }
             let prefsShow = UserDefaults.standard.optionalBool(forKey: "show-notifications") ?? true
-            if show != prefsShow{
+            if show != prefsShow {
                 UserDefaults.standard.setValue(show, forKey: "show-notifications")
             }
             result(true)
             return
         }
+        
         result(true)
     }
     
-    func makeCall(to: String)
-    {
-        if (self.call != nil && self.call?.state == .connected) {
+    // MARK: - Call Management
+    
+    func makeCall(to: String) {
+        if let call = self.call, call.state == .connected {
             self.userInitiatedDisconnect = true
-            performEndCallAction(uuid: self.call!.uuid!)            
+            performEndCallAction(uuid: call.uuid!)
         } else {
             let uuid = UUID()
             
-            self.checkRecordPermission { (permissionGranted) in
-                if (!permissionGranted) {
-                    let alertController: UIAlertController = UIAlertController(title: String(format:  NSLocalizedString("mic_permission_title", comment: "") , SwiftTwilioVoicePlugin.appName),
-                                                                               message: NSLocalizedString( "mic_permission_subtitle", comment: ""),
-                                                                               preferredStyle: .alert)
+            self.checkRecordPermission { permissionGranted in
+                if !permissionGranted {
+                    let alertController = UIAlertController(
+                        title: String(format: NSLocalizedString("mic_permission_title", comment: ""), SwiftTwilioVoicePlugin.appName),
+                        message: NSLocalizedString("mic_permission_subtitle", comment: ""),
+                        preferredStyle: .alert
+                    )
                     
-                    let continueWithMic: UIAlertAction = UIAlertAction(title: NSLocalizedString("btn_continue_no_mic", comment: ""),
-                                                                       style: .default,
-                                                                       handler: { (action) in
-                                                                        self.performStartCallAction(uuid: uuid, handle: to)
-                                                                       })
-                    alertController.addAction(continueWithMic)
+                    alertController.addAction(UIAlertAction(
+                        title: NSLocalizedString("btn_continue_no_mic", comment: ""),
+                        style: .default
+                    ) { _ in
+                        self.performStartCallAction(uuid: uuid, handle: to)
+                    })
                     
-                    let goToSettings: UIAlertAction = UIAlertAction(title:NSLocalizedString("btn_settings", comment: ""),
-                                                                    style: .default,
-                                                                    handler: { (action) in
-                                                                        UIApplication.shared.open(URL(string: UIApplication.openSettingsURLString)!,
-                                                                                                  options: [UIApplication.OpenExternalURLOptionsKey.universalLinksOnly: false],
-                                                                                                  completionHandler: nil)
-                                                                    })
-                    alertController.addAction(goToSettings)
+                    alertController.addAction(UIAlertAction(
+                        title: NSLocalizedString("btn_settings", comment: ""),
+                        style: .default
+                    ) { _ in
+                        UIApplication.shared.open(URL(string: UIApplication.openSettingsURLString)!)
+                    })
                     
-                    let cancel: UIAlertAction = UIAlertAction(title: NSLocalizedString("btn_cancel", comment: ""),
-                                                              style: .cancel,
-                                                              handler: { (action) in
-                                                                //self.toggleUIState(isEnabled: true, showCallControl: false)
-                                                                //self.stopSpin()
-                                                              })
-                    alertController.addAction(cancel)
-                    guard let currentViewController = UIApplication.shared.keyWindow?.topMostViewController() else {
-                        return
+                    alertController.addAction(UIAlertAction(
+                        title: NSLocalizedString("btn_cancel", comment: ""),
+                        style: .cancel
+                    ))
+                    
+                    if let currentViewController = UIApplication.shared.keyWindow?.topMostViewController() {
+                        currentViewController.present(alertController, animated: true)
                     }
-                    currentViewController.present(alertController, animated: true, completion: nil)
-                    
                 } else {
                     self.performStartCallAction(uuid: uuid, handle: to)
                 }
@@ -336,283 +477,224 @@ public class SwiftTwilioVoicePlugin: NSObject, FlutterPlugin,  FlutterStreamHand
     func checkRecordPermission(completion: @escaping (_ permissionGranted: Bool) -> Void) {
         switch AVAudioSession.sharedInstance().recordPermission {
         case .granted:
-            // Record permission already granted.
             completion(true)
-            break
         case .denied:
-            // Record permission denied.
             completion(false)
-            break
         case .undetermined:
-            // Requesting record permission.
-            // Optional: pop up app dialog to let the users know if they want to request.
-            AVAudioSession.sharedInstance().requestRecordPermission({ (granted) in
+            AVAudioSession.sharedInstance().requestRecordPermission { granted in
                 completion(granted)
-            })
-            break
-        default:
-            completion(false)
-            break
-        }
-    }
-    
-    
-    // MARK: PKPushRegistryDelegate
-    public func pushRegistry(_ registry: PKPushRegistry, didUpdate credentials: PKPushCredentials, for type: PKPushType) {
-        self.sendPhoneCallEvents(description: "LOG|pushRegistry:didUpdatePushCredentials:forType:", isError: false)
-        
-        if (type != .voIP) {
-            return
-        }
-        
-        guard registrationRequired() || deviceToken != credentials.token else { return }
-
-        let deviceToken = credentials.token
-
-        self.sendPhoneCallEvents(description: "LOG|pushRegistry:attempting to register with twilio", isError: false)
-        if let token = accessToken {
-            TwilioVoiceSDK.register(accessToken: token, deviceToken: deviceToken) { (error) in
-                if let error = error {
-                    self.sendPhoneCallEvents(description: "LOG|An error occurred while registering: \(error.localizedDescription)", isError: false)
-                    self.sendPhoneCallEvents(description: "DEVICETOKEN|\(String(decoding: deviceToken, as: UTF8.self))", isError: false)
-                }
-                else {
-                    self.sendPhoneCallEvents(description: "LOG|Successfully registered for VoIP push notifications.", isError: false)
-                }
             }
+        @unknown default:
+            completion(false)
         }
-        self.deviceToken = deviceToken
-        UserDefaults.standard.set(Date(), forKey: kCachedBindingDate)
-
     }
     
-    /**
-      * The TTL of a registration is 1 year. The TTL for registration for this device/identity pair is reset to
-      * 1 year whenever a new registration occurs or a push notification is sent to this device/identity pair.
-      * This method checks if binding exists in UserDefaults, and if half of TTL has been passed then the method
-      * will return true, else false.
-      */
-     func registrationRequired() -> Bool {
-         guard
-             let lastBindingCreated = UserDefaults.standard.object(forKey: kCachedBindingDate)
-         else { return true }
-
-         let date = Date()
-         var components = DateComponents()
-         components.setValue(kRegistrationTTLInDays/2, for: .day)
-         let expirationDate = Calendar.current.date(byAdding: components, to: lastBindingCreated as! Date)!
-
-         if expirationDate.compare(date) == ComparisonResult.orderedDescending {
-             return false
-         }
-         return true;
-     }
+    // MARK: - PKPushRegistryDelegate (Legacy - now handled via AppDelegate)
+    
+    public func pushRegistry(_ registry: PKPushRegistry, didUpdate credentials: PKPushCredentials, for type: PKPushType) {
+        // This is called if PKPushRegistry is initialized in the plugin (legacy path)
+        // For iOS 26, AppDelegate should handle this
+        NSLog("[TwilioVoice] pushRegistry didUpdate credentials (plugin)")
+        guard type == .voIP else { return }
+        handleVoIPTokenUpdate(token: credentials.token)
+    }
     
     public func pushRegistry(_ registry: PKPushRegistry, didInvalidatePushTokenFor type: PKPushType) {
-        self.sendPhoneCallEvents(description: "LOG|pushRegistry:didInvalidatePushTokenForType:", isError: false)
-        
-        if (type != .voIP) {
-            return
-        }
-        
+        NSLog("[TwilioVoice] pushRegistry didInvalidate (plugin)")
+        guard type == .voIP else { return }
         self.unregister()
     }
     
-    func unregister() {
+    public func pushRegistry(_ registry: PKPushRegistry, didReceiveIncomingPushWith payload: PKPushPayload, for type: PKPushType) {
+        // Deprecated - iOS 11+
+        NSLog("[TwilioVoice] pushRegistry didReceiveIncomingPush (deprecated)")
+        guard type == .voIP else { return }
+        TwilioVoiceSDK.handleNotification(payload.dictionaryPayload, delegate: self, delegateQueue: nil)
+    }
+    
+    public func pushRegistry(_ registry: PKPushRegistry, didReceiveIncomingPushWith payload: PKPushPayload, for type: PKPushType, completion: @escaping () -> Void) {
+        // Legacy iOS 11+ handler - for non-iOS 26 builds
+        NSLog("[TwilioVoice] pushRegistry didReceiveIncomingPush with completion (plugin)")
+        guard type == .voIP else { completion(); return }
         
-        guard let deviceToken = deviceToken, let token = accessToken else {
-            return
+        // Store completion - will be called AFTER reportNewIncomingCall
+        self.pendingPushCompletion = completion
+        
+        // Safety timeout
+        pushCompletionTimer?.cancel()
+        let timer = DispatchWorkItem { [weak self] in
+            self?.completePendingPush()
+        }
+        pushCompletionTimer = timer
+        DispatchQueue.main.asyncAfter(deadline: .now() + 5, execute: timer)
+        
+        TwilioVoiceSDK.handleNotification(payload.dictionaryPayload, delegate: self, delegateQueue: nil)
+    }
+    
+    // MARK: - Registration
+    
+    func registrationRequired() -> Bool {
+        guard let lastBindingCreated = UserDefaults.standard.object(forKey: kCachedBindingDate) as? Date else {
+            return true
         }
         
+        var components = DateComponents()
+        components.setValue(kRegistrationTTLInDays / 2, for: .day)
+        let expirationDate = Calendar.current.date(byAdding: components, to: lastBindingCreated)!
+        
+        return Date() >= expirationDate
+    }
+    
+    func unregister() {
+        guard let deviceToken = deviceToken, let token = accessToken else { return }
         self.unregisterTokens(token: token, deviceToken: deviceToken)
     }
     
     func unregisterTokens(token: String, deviceToken: Data) {
-        TwilioVoiceSDK.unregister(accessToken: token, deviceToken: deviceToken) { (error) in
+        TwilioVoiceSDK.unregister(accessToken: token, deviceToken: deviceToken) { error in
             if let error = error {
-                self.sendPhoneCallEvents(description: "LOG|An error occurred while unregistering: \(error.localizedDescription)", isError: false)
+                self.sendPhoneCallEvents(description: "LOG|Unregister error: \(error.localizedDescription)", isError: false)
             } else {
-                self.sendPhoneCallEvents(description: "LOG|Successfully unregistered from VoIP push notifications.", isError: false)
+                self.sendPhoneCallEvents(description: "LOG|Successfully unregistered", isError: false)
             }
         }
-        
-        // Commenting out because we need the kCachedDeviceToken for users loggin in and out within the same session
-        // UserDefaults.standard.removeObject(forKey: kCachedDeviceToken)
-        
-        // Remove the cached binding as credentials are invalidated
         UserDefaults.standard.removeObject(forKey: kCachedBindingDate)
     }
     
-    /**
-     * Try using the `pushRegistry:didReceiveIncomingPushWithPayload:forType:withCompletionHandler:` method if
-     * your application is targeting iOS 11. According to the docs, this delegate method is deprecated by Apple.
-     */
-    public func pushRegistry(_ registry: PKPushRegistry, didReceiveIncomingPushWith payload: PKPushPayload, for type: PKPushType) {
-        self.sendPhoneCallEvents(description: "LOG|pushRegistry:didReceiveIncomingPushWithPayload:forType:", isError: false)
-        
-        if (type == PKPushType.voIP) {
-            TwilioVoiceSDK.handleNotification(payload.dictionaryPayload, delegate: self, delegateQueue: nil)
-        }
-    }
+    // MARK: - TVONotificationDelegate
     
-    /**
-     * This delegate method is available on iOS 11 and above. Call the completion handler once the
-     * notification payload is passed to the `TwilioVoice.handleNotification()` method.
-     */
-    public func pushRegistry(_ registry: PKPushRegistry, didReceiveIncomingPushWith payload: PKPushPayload, for type: PKPushType, completion: @escaping () -> Void) {
-        self.sendPhoneCallEvents(description: "LOG|pushRegistry:didReceiveIncomingPushWithPayload:forType:completion:", isError: false)
-        // Save for later when the notification is properly handled.
-//        self.incomingPushCompletionCallback = completion
-        
-        if (type == PKPushType.voIP) {
-            TwilioVoiceSDK.handleNotification(payload.dictionaryPayload, delegate: self, delegateQueue: nil)
-        }
-        
-        if let version = Float(UIDevice.current.systemVersion), version < 13.0 {
-            // Save for later when the notification is properly handled.
-            self.incomingPushCompletionCallback = completion
-        } else {
-            /**
-             * The Voice SDK processes the call notification and returns the call invite synchronously. Report the incoming call to
-             * CallKit and fulfill the completion before exiting this callback method.
-             */
-            completion()
-        }
-    }
-    
-    func incomingPushHandled() {
-        if let completion = self.incomingPushCompletionCallback {
-            self.incomingPushCompletionCallback = nil
-            completion()
-        }
-    }
-    
-    // MARK: TVONotificaitonDelegate
     public func callInviteReceived(callInvite: CallInvite) {
-        self.sendPhoneCallEvents(description: "LOG|callInviteReceived:", isError: false)
+        NSLog("[TwilioVoice] callInviteReceived")
+        self.sendPhoneCallEvents(description: "LOG|callInviteReceived", isError: false)
         
-        /**
-         * The TTL of a registration is 1 year. The TTL for registration for this device/identity
-         * pair is reset to 1 year whenever a new registration occurs or a push notification is
-         * sent to this device/identity pair.
-         */
         UserDefaults.standard.set(Date(), forKey: kCachedBindingDate)
         
-        var from:String = callInvite.from ?? defaultCaller
+        var from: String = callInvite.from ?? defaultCaller
         from = from.replacingOccurrences(of: "client:", with: "")
         
         self.sendPhoneCallEvents(description: "Ringing|\(from)|\(callInvite.to)|Incoming\(formatCustomParams(params: callInvite.customParameters))", isError: false)
-        reportIncomingCall(from: from, uuid: callInvite.uuid)
+        
         self.callInvite = callInvite
+        
+        // Report to CallKit, then complete the push (F1 fix)
+        reportIncomingCall(from: from, uuid: callInvite.uuid) { [weak self] error in
+            if let error = error {
+                NSLog("[TwilioVoice] reportIncomingCall failed: \(error.localizedDescription)")
+                // F7 fix: Clean up on failure
+                self?.callInvite?.reject()
+                self?.callInvite = nil
+            }
+            // Complete push AFTER reporting (F1 fix - critical for iOS 26)
+            self?.completePendingPush()
+        }
     }
     
-    func formatCustomParams(params: [String:Any]?)->String{
-        guard let customParameters = params else{return ""}
-        do{
+    func formatCustomParams(params: [String: Any]?) -> String {
+        guard let customParameters = params else { return "" }
+        do {
             let jsonData = try JSONSerialization.data(withJSONObject: customParameters)
-            if let jsonStr = String(data: jsonData, encoding: .utf8){
-                return "|\(jsonStr )"
+            if let jsonStr = String(data: jsonData, encoding: .utf8) {
+                return "|\(jsonStr)"
             }
-        }catch{
+        } catch {
             print("unable to send custom parameters")
         }
         return ""
     }
     
     public func cancelledCallInviteReceived(cancelledCallInvite: CancelledCallInvite, error: Error) {
+        NSLog("[TwilioVoice] cancelledCallInviteReceived")
         self.sendPhoneCallEvents(description: "Missed Call", isError: false)
-        self.sendPhoneCallEvents(description: "LOG|cancelledCallInviteCanceled:", isError: false)
+        self.sendPhoneCallEvents(description: "LOG|cancelledCallInviteReceived", isError: false)
+        
         self.showMissedCallNotification(from: cancelledCallInvite.from, to: cancelledCallInvite.to)
-        if (self.callInvite == nil) {
-            self.sendPhoneCallEvents(description: "LOG|No pending call invite", isError: false)
-            return
-        }
         
         if let ci = self.callInvite {
-            performEndCallAction(uuid: ci.uuid)
+            // Report end to CallKit
+            callKitProvider.reportCall(with: ci.uuid, endedAt: Date(), reason: .answeredElsewhere)
+            self.callInvite = nil
         }
+        
+        // Complete any pending push
+        completePendingPush()
     }
     
-    func showMissedCallNotification(from:String?, to:String?){
-        guard UserDefaults.standard.optionalBool(forKey: "show-notifications") ?? true else{return}
+    func showMissedCallNotification(from: String?, to: String?) {
+        guard UserDefaults.standard.optionalBool(forKey: "show-notifications") ?? true else { return }
+        
         let notificationCenter = UNUserNotificationCenter.current()
-
-       
-        notificationCenter.getNotificationSettings { (settings) in
-          if settings.authorizationStatus == .authorized {
+        notificationCenter.getNotificationSettings { settings in
+            guard settings.authorizationStatus == .authorized else { return }
+            
             let content = UNMutableNotificationContent()
-            var userName:String?
-            if var from = from{
+            var userName: String?
+            
+            if var from = from {
                 from = from.replacingOccurrences(of: "client:", with: "")
-                content.userInfo = ["type":"twilio-missed-call", "From":from]
-                if let to = to{
+                content.userInfo = ["type": "twilio-missed-call", "From": from]
+                if let to = to {
                     content.userInfo["To"] = to
                 }
                 userName = self.clients[from]
             }
             
             let title = userName ?? self.clients["defaultCaller"] ?? self.defaultCaller
-            content.title = String(format:  NSLocalizedString("notification_missed_call", comment: ""),title)
-
+            content.title = String(format: NSLocalizedString("notification_missed_call", comment: ""), title)
+            
             let trigger = UNTimeIntervalNotificationTrigger(timeInterval: 1, repeats: false)
-            let request = UNNotificationRequest(identifier: UUID().uuidString,
-                                                content: content,
-                                                trigger: trigger)
+            let request = UNNotificationRequest(identifier: UUID().uuidString, content: content, trigger: trigger)
             
-                notificationCenter.add(request) { (error) in
-                    if let error = error {
-                        print("Notification Error: ", error)
-                    }
+            notificationCenter.add(request) { error in
+                if let error = error {
+                    print("Notification Error: ", error)
                 }
-            
-          }
+            }
         }
     }
     
-    // MARK: TVOCallDelegate
+    // MARK: - TVOCallDelegate
+    
     public func callDidStartRinging(call: Call) {
-        let direction = (self.callOutgoing ? "Outgoing" : "Incoming")
-        let from = (call.from ?? self.identity)
-        let to = (call.to ?? self.callTo)
+        let direction = self.callOutgoing ? "Outgoing" : "Incoming"
+        let from = call.from ?? self.identity
+        let to = call.to ?? self.callTo
         self.sendPhoneCallEvents(description: "Ringing|\(from)|\(to)|\(direction)", isError: false)
-        
-        //self.placeCallButton.setTitle("Ringing", for: .normal)
     }
     
     public func callDidConnect(call: Call) {
-        let direction = (self.callOutgoing ? "Outgoing" : "Incoming")
-        let from = (call.from ?? self.identity)
-        let to = (call.to ?? self.callTo)
+        let direction = self.callOutgoing ? "Outgoing" : "Incoming"
+        let from = call.from ?? self.identity
+        let to = call.to ?? self.callTo
         self.sendPhoneCallEvents(description: "Connected|\(from)|\(to)|\(direction)", isError: false)
         
-        if let callKitCompletionCallback = callKitCompletionCallback {
-            callKitCompletionCallback(true)
+        if let callback = callKitCompletionCallback {
+            callback(true)
         }
         
         toggleAudioRoute(toSpeaker: false)
     }
     
     public func call(call: Call, isReconnectingWithError error: Error) {
-        self.sendPhoneCallEvents(description: "LOG|call:isReconnectingWithError:", isError: false)
-        
+        self.sendPhoneCallEvents(description: "LOG|call:isReconnectingWithError", isError: false)
     }
     
     public func callDidReconnect(call: Call) {
-        self.sendPhoneCallEvents(description: "LOG|callDidReconnect:", isError: false)
+        self.sendPhoneCallEvents(description: "LOG|callDidReconnect", isError: false)
     }
     
     public func callDidFailToConnect(call: Call, error: Error) {
         self.sendPhoneCallEvents(description: "LOG|Call failed to connect: \(error.localizedDescription)", isError: false)
         self.sendPhoneCallEvents(description: "Call Ended", isError: false)
-        if(error.localizedDescription.contains("Access Token expired")){
+        
+        if error.localizedDescription.contains("Access Token expired") {
             self.sendPhoneCallEvents(description: "DEVICETOKEN", isError: false)
         }
-        if let completion = self.callKitCompletionCallback {
-            completion(false)
+        
+        callKitCompletionCallback?(false)
+        
+        if let uuid = call.uuid {
+            callKitProvider.reportCall(with: uuid, endedAt: Date(), reason: .failed)
         }
-        
-        
-        callKitProvider.reportCall(with: call.uuid!, endedAt: Date(), reason: CXCallEndedReason.failed)
         callDisconnected()
     }
     
@@ -624,12 +706,12 @@ public class SwiftTwilioVoicePlugin: NSObject, FlutterPlugin,  FlutterStreamHand
         
         if !self.userInitiatedDisconnect {
             var reason = CXCallEndedReason.remoteEnded
-            self.sendPhoneCallEvents(description: "LOG|User initiated disconnect", isError: false)
             if error != nil {
                 reason = .failed
             }
-            
-            self.callKitProvider.reportCall(with: call.uuid!, endedAt: Date(), reason: reason)
+            if let uuid = call.uuid {
+                self.callKitProvider.reportCall(with: uuid, endedAt: Date(), reason: reason)
+            }
         }
         
         callDisconnected()
@@ -637,28 +719,19 @@ public class SwiftTwilioVoicePlugin: NSObject, FlutterPlugin,  FlutterStreamHand
     
     func callDisconnected() {
         self.sendPhoneCallEvents(description: "LOG|Call Disconnected", isError: false)
-        if (self.call != nil) {
-            
-            self.sendPhoneCallEvents(description: "LOG|Setting call to nil", isError: false)
-            self.call = nil
-        }
-        if (self.callInvite != nil) {
-            self.callInvite = nil
-        }
-        
+        self.call = nil
+        self.callInvite = nil
         self.callOutgoing = false
         self.userInitiatedDisconnect = false
-        
     }
     
+    // MARK: - AVAudioSession
     
-    // MARK: AVAudioSession
     func toggleAudioRoute(toSpeaker: Bool) {
-        // The mode set by the Voice SDK is "VoiceChat" so the default audio route is the built-in receiver. Use port override to switch the route.
         audioDevice.block = {
             DefaultAudioDevice.DefaultAVAudioSessionConfigurationBlock()
             do {
-                if (toSpeaker) {
+                if toSpeaker {
                     try AVAudioSession.sharedInstance().overrideOutputAudioPort(.speaker)
                 } else {
                     try AVAudioSession.sharedInstance().overrideOutputAudioPort(.none)
@@ -670,9 +743,10 @@ public class SwiftTwilioVoicePlugin: NSObject, FlutterPlugin,  FlutterStreamHand
         audioDevice.block()
     }
     
-    // MARK: CXProviderDelegate
+    // MARK: - CXProviderDelegate
+    
     public func providerDidReset(_ provider: CXProvider) {
-        self.sendPhoneCallEvents(description: "LOG|providerDidReset:", isError: false)
+        self.sendPhoneCallEvents(description: "LOG|providerDidReset", isError: false)
         audioDevice.isEnabled = false
     }
     
@@ -681,68 +755,66 @@ public class SwiftTwilioVoicePlugin: NSObject, FlutterPlugin,  FlutterStreamHand
     }
     
     public func provider(_ provider: CXProvider, didActivate audioSession: AVAudioSession) {
-        self.sendPhoneCallEvents(description: "LOG|provider:didActivateAudioSession:", isError: false)
+        self.sendPhoneCallEvents(description: "LOG|provider:didActivateAudioSession", isError: false)
         audioDevice.isEnabled = true
     }
     
     public func provider(_ provider: CXProvider, didDeactivate audioSession: AVAudioSession) {
-        self.sendPhoneCallEvents(description: "LOG|provider:didDeactivateAudioSession:", isError: false)
+        self.sendPhoneCallEvents(description: "LOG|provider:didDeactivateAudioSession", isError: false)
         audioDevice.isEnabled = false
     }
     
     public func provider(_ provider: CXProvider, timedOutPerforming action: CXAction) {
-        self.sendPhoneCallEvents(description: "LOG|provider:timedOutPerformingAction:", isError: false)
+        self.sendPhoneCallEvents(description: "LOG|provider:timedOutPerformingAction", isError: false)
     }
     
     public func provider(_ provider: CXProvider, perform action: CXStartCallAction) {
-        self.sendPhoneCallEvents(description: "LOG|provider:performStartCallAction:", isError: false)
-        
+        self.sendPhoneCallEvents(description: "LOG|provider:performStartCallAction", isError: false)
         
         provider.reportOutgoingCall(with: action.callUUID, startedConnectingAt: Date())
         
-        self.performVoiceCall(uuid: action.callUUID, client: "") { (success) in
-            if (success) {
-                self.sendPhoneCallEvents(description: "LOG|provider:performAnswerVoiceCall() successful", isError: false)
+        self.performVoiceCall(uuid: action.callUUID, client: "") { success in
+            if success {
+                self.sendPhoneCallEvents(description: "LOG|performVoiceCall successful", isError: false)
                 provider.reportOutgoingCall(with: action.callUUID, connectedAt: Date())
             } else {
-                self.sendPhoneCallEvents(description: "LOG|provider:performVoiceCall() failed", isError: false)
+                self.sendPhoneCallEvents(description: "LOG|performVoiceCall failed", isError: false)
             }
         }
         action.fulfill()
     }
     
     public func provider(_ provider: CXProvider, perform action: CXAnswerCallAction) {
-        self.sendPhoneCallEvents(description: "LOG|provider:performAnswerCallAction:", isError: false)
+        self.sendPhoneCallEvents(description: "LOG|provider:performAnswerCallAction", isError: false)
         
-        
-        self.performAnswerVoiceCall(uuid: action.callUUID) { (success) in
+        // F2 fix: Only fulfill after successful answer, fail otherwise
+        self.performAnswerVoiceCall(uuid: action.callUUID) { success in
             if success {
-                self.sendPhoneCallEvents(description: "LOG|provider:performAnswerVoiceCall() successful", isError: false)
+                self.sendPhoneCallEvents(description: "LOG|performAnswerVoiceCall successful", isError: false)
+                action.fulfill()
             } else {
-                self.sendPhoneCallEvents(description: "LOG|provider:performAnswerVoiceCall() failed:", isError: false)
+                self.sendPhoneCallEvents(description: "LOG|performAnswerVoiceCall failed", isError: false)
+                action.fail()
             }
         }
-        
-        action.fulfill()
     }
     
     public func provider(_ provider: CXProvider, perform action: CXEndCallAction) {
-        self.sendPhoneCallEvents(description: "LOG|provider:performEndCallAction:", isError: false)
+        self.sendPhoneCallEvents(description: "LOG|provider:performEndCallAction", isError: false)
         
-        
-        if (self.callInvite != nil) {
-            self.sendPhoneCallEvents(description: "LOG|provider:performEndCallAction: rejecting call", isError: false)
-            self.callInvite?.reject()
+        if let callInvite = self.callInvite {
+            self.sendPhoneCallEvents(description: "LOG|Rejecting call", isError: false)
+            callInvite.reject()
             self.callInvite = nil
-        }else if let call = self.call {
-            self.sendPhoneCallEvents(description: "LOG|provider:performEndCallAction: disconnecting call", isError: false)
+        } else if let call = self.call {
+            self.sendPhoneCallEvents(description: "LOG|Disconnecting call", isError: false)
             call.disconnect()
         }
         action.fulfill()
     }
     
     public func provider(_ provider: CXProvider, perform action: CXSetHeldCallAction) {
-        self.sendPhoneCallEvents(description: "LOG|provider:performSetHeldAction:", isError: false)
+        self.sendPhoneCallEvents(description: "LOG|provider:performSetHeldAction", isError: false)
         if let call = self.call {
             call.isOnHold = action.isOnHold
             action.fulfill()
@@ -752,8 +824,7 @@ public class SwiftTwilioVoicePlugin: NSObject, FlutterPlugin,  FlutterStreamHand
     }
     
     public func provider(_ provider: CXProvider, perform action: CXSetMutedCallAction) {
-        self.sendPhoneCallEvents(description: "LOG|provider:performSetMutedAction:", isError: false)
-        
+        self.sendPhoneCallEvents(description: "LOG|provider:performSetMutedAction", isError: false)
         if let call = self.call {
             call.isMuted = action.isMuted
             action.fulfill()
@@ -762,19 +833,20 @@ public class SwiftTwilioVoicePlugin: NSObject, FlutterPlugin,  FlutterStreamHand
         }
     }
     
-    // MARK: Call Kit Actions
+    // MARK: - CallKit Actions
+    
     func performStartCallAction(uuid: UUID, handle: String) {
         let callHandle = CXHandle(type: .generic, value: handle)
         let startCallAction = CXStartCallAction(call: uuid, handle: callHandle)
         let transaction = CXTransaction(action: startCallAction)
         
-        callKitCallController.request(transaction)  { error in
+        callKitCallController.request(transaction) { error in
             if let error = error {
-                self.sendPhoneCallEvents(description: "LOG|StartCallAction transaction request failed: \(error.localizedDescription)", isError: false)
+                self.sendPhoneCallEvents(description: "LOG|StartCallAction failed: \(error.localizedDescription)", isError: false)
                 return
             }
             
-            self.sendPhoneCallEvents(description: "LOG|StartCallAction transaction request successful", isError: false)
+            self.sendPhoneCallEvents(description: "LOG|StartCallAction successful", isError: false)
             
             let callUpdate = CXCallUpdate()
             callUpdate.remoteHandle = callHandle
@@ -789,7 +861,7 @@ public class SwiftTwilioVoicePlugin: NSObject, FlutterPlugin,  FlutterStreamHand
         }
     }
     
-    func reportIncomingCall(from: String, uuid: UUID) {
+    func reportIncomingCall(from: String, uuid: UUID, completion: ((Error?) -> Void)? = nil) {
         let callHandle = CXHandle(type: .generic, value: from)
         
         let callUpdate = CXCallUpdate()
@@ -803,23 +875,23 @@ public class SwiftTwilioVoicePlugin: NSObject, FlutterPlugin,  FlutterStreamHand
         
         callKitProvider.reportNewIncomingCall(with: uuid, update: callUpdate) { error in
             if let error = error {
-                self.sendPhoneCallEvents(description: "LOG|Failed to report incoming call successfully: \(error.localizedDescription).", isError: false)
+                self.sendPhoneCallEvents(description: "LOG|Failed to report incoming call: \(error.localizedDescription)", isError: false)
             } else {
-                self.sendPhoneCallEvents(description: "LOG|Incoming call successfully reported.", isError: false)
+                self.sendPhoneCallEvents(description: "LOG|Incoming call reported successfully", isError: false)
             }
+            completion?(error)
         }
     }
     
     func performEndCallAction(uuid: UUID) {
-        
-        self.sendPhoneCallEvents(description: "LOG|performEndCallAction method invoked", isError: false)
+        self.sendPhoneCallEvents(description: "LOG|performEndCallAction invoked", isError: false)
         
         let endCallAction = CXEndCallAction(call: uuid)
         let transaction = CXTransaction(action: endCallAction)
         
         callKitCallController.request(transaction) { error in
             if let error = error {
-                self.sendPhoneCallEvents(description: "End Call Failed: \(error.localizedDescription).", isError: true)
+                self.sendPhoneCallEvents(description: "End Call Failed: \(error.localizedDescription)", isError: true)
             } else {
                 self.sendPhoneCallEvents(description: "Call Ended", isError: false)
             }
@@ -832,9 +904,9 @@ public class SwiftTwilioVoicePlugin: NSObject, FlutterPlugin,  FlutterStreamHand
             return
         }
         
-        let connectOptions: ConnectOptions = ConnectOptions(accessToken: token) { (builder) in
+        let connectOptions = ConnectOptions(accessToken: token) { builder in
             for (key, value) in self.callArgs {
-                if (key != "From") {
+                if key != "From" {
                     builder.params[key] = "\(value)"
                 }
             }
@@ -846,102 +918,92 @@ public class SwiftTwilioVoicePlugin: NSObject, FlutterPlugin,  FlutterStreamHand
     }
     
     func performAnswerVoiceCall(uuid: UUID, completionHandler: @escaping (Bool) -> Swift.Void) {
-        if let ci = self.callInvite {
-            let acceptOptions: AcceptOptions = AcceptOptions(callInvite: ci) { (builder) in
-                builder.uuid = ci.uuid
-            }
-            self.sendPhoneCallEvents(description: "LOG|performAnswerVoiceCall: answering call", isError: false)
-            let theCall = ci.accept(options: acceptOptions, delegate: self)
-            self.sendPhoneCallEvents(description: "Answer|\(theCall.from!)|\(theCall.to!)\(formatCustomParams(params: ci.customParameters))", isError:false)
-            self.call = theCall
-            self.callKitCompletionCallback = completionHandler
-            self.callInvite = nil
-            
-            guard #available(iOS 13, *) else {
-                self.incomingPushHandled()
-                return
-            }
-        } else {
+        guard let ci = self.callInvite else {
             self.sendPhoneCallEvents(description: "LOG|No CallInvite matches the UUID", isError: false)
+            // F2 fix: Report failure and clean up
+            callKitProvider.reportCall(with: uuid, endedAt: Date(), reason: .failed)
+            completionHandler(false)
+            return
         }
+        
+        let acceptOptions = AcceptOptions(callInvite: ci) { builder in
+            builder.uuid = ci.uuid
+        }
+        
+        self.sendPhoneCallEvents(description: "LOG|performAnswerVoiceCall: answering call", isError: false)
+        let theCall = ci.accept(options: acceptOptions, delegate: self)
+        self.sendPhoneCallEvents(description: "Answer|\(theCall.from ?? "")|\(theCall.to ?? "")\(formatCustomParams(params: ci.customParameters))", isError: false)
+        self.call = theCall
+        self.callKitCompletionCallback = completionHandler
+        self.callInvite = nil
+        
+        completionHandler(true)
     }
     
-    public func onListen(withArguments arguments: Any?,
-                         eventSink: @escaping FlutterEventSink) -> FlutterError? {
+    // MARK: - FlutterStreamHandler
+    
+    public func onListen(withArguments arguments: Any?, eventSink: @escaping FlutterEventSink) -> FlutterError? {
         self.eventSink = eventSink
-        
-        NotificationCenter.default.addObserver(
-            self,
-            selector: #selector(CallDelegate.callDidDisconnect),
-            name: NSNotification.Name(rawValue: "PhoneCallEvent"),
-            object: nil)
-        
         return nil
     }
     
     public func onCancel(withArguments arguments: Any?) -> FlutterError? {
-        NotificationCenter.default.removeObserver(self)
         eventSink = nil
         return nil
     }
     
+    // MARK: - Event Sending
+    
     private func sendPhoneCallEvents(description: String, isError: Bool) {
-        NSLog(description)
-        guard let eventSink = eventSink else {
-            return
-        }
+        NSLog("[TwilioVoice] \(description)")
         
-        if isError
-        {
-            eventSink(FlutterError(code: "unavailable",
-                                   message: description,
-                                   details: nil))
-        }
-        else
-        {
-            eventSink(description)
+        DispatchQueue.main.async {
+            guard let eventSink = self.eventSink else { return }
+            
+            if isError {
+                eventSink(FlutterError(code: "unavailable", message: description, details: nil))
+            } else {
+                eventSink(description)
+            }
         }
     }
     
-
-
+    // MARK: - UNUserNotificationCenterDelegate
+    
     public func userNotificationCenter(_ center: UNUserNotificationCenter, didReceive response: UNNotificationResponse, withCompletionHandler completionHandler: @escaping () -> Void) {
         let userInfo = response.notification.request.content.userInfo
         
-        if let type = userInfo["type"] as? String, type == "twilio-missed-call", let user = userInfo["From"] as? String{
+        if let type = userInfo["type"] as? String, type == "twilio-missed-call", let user = userInfo["From"] as? String {
             self.callTo = user
-            if let to = userInfo["To"] as? String{
+            if let to = userInfo["To"] as? String {
                 self.identity = to
             }
             makeCall(to: callTo)
-            completionHandler()
             self.sendPhoneCallEvents(description: "ReturningCall|\(identity)|\(user)|Outgoing", isError: false)
         }
-    }
-
-    public func userNotificationCenter(_ center: UNUserNotificationCenter,
-                                willPresent notification: UNNotification,
-                                withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void) {
-        let userInfo = notification.request.content.userInfo
-        if let type = userInfo["type"] as? String, type == "twilio-missed-call"{
-            completionHandler([.alert])
-        }
+        completionHandler()
     }
     
+    public func userNotificationCenter(_ center: UNUserNotificationCenter, willPresent notification: UNNotification, withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void) {
+        let userInfo = notification.request.content.userInfo
+        if let type = userInfo["type"] as? String, type == "twilio-missed-call" {
+            completionHandler([.alert])
+        } else {
+            completionHandler([])
+        }
+    }
 }
+
+// MARK: - Extensions
 
 extension UIWindow {
     func topMostViewController() -> UIViewController? {
-        guard let rootViewController = self.rootViewController else {
-            return nil
-        }
+        guard let rootViewController = self.rootViewController else { return nil }
         return topViewController(for: rootViewController)
     }
     
     func topViewController(for rootViewController: UIViewController?) -> UIViewController? {
-        guard let rootViewController = rootViewController else {
-            return nil
-        }
+        guard let rootViewController = rootViewController else { return nil }
         guard let presentedViewController = rootViewController.presentedViewController else {
             return rootViewController
         }
@@ -957,6 +1019,7 @@ extension UIWindow {
         }
     }
 }
+
 extension UserDefaults {
     public func optionalBool(forKey defaultName: String) -> Bool? {
         if let value = value(forKey: defaultName) {
@@ -966,10 +1029,8 @@ extension UserDefaults {
     }
 }
 
-
 extension Data {
     var hexString: String {
-        let hexString = map { String(format: "%02.2hhx", $0) }.joined()
-        return hexString
+        return map { String(format: "%02.2hhx", $0) }.joined()
     }
 }

--- a/ios/twilio_voice.podspec
+++ b/ios/twilio_voice.podspec
@@ -15,11 +15,11 @@ Pod::Spec.new do |s|
   s.source           = { :path => '.' }
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
-  s.dependency 'TwilioVoice','~> 6.3.0'
-  s.platform = :ios, '11.0'
+  s.dependency 'TwilioVoice','~> 6.13.6'
+  s.platform = :ios, '13.0'
 
   # Flutter.framework does not contain a i386 slice.
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'i386' }
   s.swift_version = '5.0'
-  s.ios.deployment_target = '11.0'
+  s.ios.deployment_target = '13.0'
 end


### PR DESCRIPTION
- Move PKPushRegistry management to AppDelegate (required for iOS 26)
- Add NotificationCenter observers for AppDelegate VoIP events
- Fix F1: Call push completion AFTER reportNewIncomingCall
- Fix F2: Move action.fulfill() to success path in CXAnswerCallAction
- Fix F7: Clean up state when reportNewIncomingCall fails
- Add singleton pattern to prevent multiple instances
- Add 5-second safety timeout for push completion
- Upgrade TwilioVoice SDK to 6.13.6
- Update deployment target to iOS 13.0